### PR TITLE
feat: add API endpoint to count environments by filter

### DIFF
--- a/env-backend/src/main/java/org/qubership/atp/environments/service/direct/EnvironmentService.java
+++ b/env-backend/src/main/java/org/qubership/atp/environments/service/direct/EnvironmentService.java
@@ -139,4 +139,6 @@ public interface EnvironmentService extends IdentifiedService<Environment> {
                                                      Integer size);
 
     Collection<GroupedByTagEnvironmentResponse> getGroupedByTagEnvironments(UUID projectId);
+
+    long getEnvironmentsCountByFilter(EnvironmentsWithFilterRequest request);
 }

--- a/env-backend/src/main/java/org/qubership/atp/environments/service/direct/impl/EnvironmentServiceImpl.java
+++ b/env-backend/src/main/java/org/qubership/atp/environments/service/direct/impl/EnvironmentServiceImpl.java
@@ -626,4 +626,9 @@ public class EnvironmentServiceImpl implements EnvironmentService {
         }
         resultMap.get(tag).getEnvironments().add(environment);
     }
+
+    @Override
+    public long getEnvironmentsCountByFilter(EnvironmentsWithFilterRequest request) {
+        return environmentRepository.getEnvironmentsCountByFilter(request);
+    }
 }

--- a/env-backend/src/main/java/org/qubership/atp/environments/service/rest/server/EnvironmentController.java
+++ b/env-backend/src/main/java/org/qubership/atp/environments/service/rest/server/EnvironmentController.java
@@ -19,7 +19,9 @@ package org.qubership.atp.environments.service.rest.server;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -359,5 +361,19 @@ public class EnvironmentController /*implements EnvironmentControllerApi*/ {
     @AuditAction(auditAction = "Delete environment {{#environmentId.toString()}}")
     public void deleteEnvironment(@PathVariable("environmentId") UUID environmentId) {
         environmentService.delete(environmentId);
+    }
+
+    /**
+     * Returns the total number of environments that match the provided filter criteria.
+     */
+    @PreAuthorize("@entityAccess.checkAccess("
+            + "T(org.qubership.atp.environments.enums.UserManagementEntities).ENVIRONMENT.getName(),"
+            + "#request.getProjectId(),'READ')")
+    @PostMapping("/environments/filter/count")
+    @Operation(description = "Returns the total count of environments matching the provided filter criteria")
+    public ResponseEntity<Map<String, Long>> getEnvironmentsCountByRequest(
+            @RequestBody EnvironmentsWithFilterRequest request) {
+        long count = environmentService.getEnvironmentsCountByFilter(request);
+        return ResponseEntity.ok(Collections.singletonMap("count", count));
     }
 }

--- a/env-rest-openapi-specifications/v1/openapi-environments-v1.yaml
+++ b/env-rest-openapi-specifications/v1/openapi-environments-v1.yaml
@@ -652,6 +652,43 @@ paths:
         '404':
           description: Not Found
       deprecated: false
+  /api/environments/filter/count:
+    post:
+      tags:
+        - environment-controller
+      summary: getEnvironmentsCountByRequest
+      operationId: getEnvironmentsCountByRequest
+      parameters:
+        - name: full
+          in: query
+          description: full
+          required: false
+          style: form
+          schema:
+            type: boolean
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnvironmentsWithFilterRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            'application/json':
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                    example: 42
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+      deprecated: false
 components:
   schemas:
     Connection:


### PR DESCRIPTION
Added a new dedicated endpoint POST /api/environments/filter/count that returns only the total count of environments matching the provided filter criteria (to support total Field for pagination). Existing endpoint POST /api/environments/filter returns complete paginated response with List of Environments in response.